### PR TITLE
Update readme to use compose v2, remove container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Jupyter-Docker-Compose
+# Jupyter Docker Compose
 
-A quick and easy setup for running Jupyter notebooks in a Dockerized environment, managed using Docker Compose. This setup makes it simple to get up and running with Jupyter, share notebooks across multiple team members, and maintain consistent environments. It is also compatible with GitHub Code Spaces for remote development.
+A quick and easy setup for running Jupyter notebooks in a Dockerized environment, managed using [Docker Compose](https://docs.docker.com/compose/). This setup makes it simple to get up and running with Jupyter, share notebooks across multiple team members, and maintain consistent environments. It is also compatible with GitHub Code Spaces for remote development.
 
 ## Features
 
@@ -26,13 +26,13 @@ cd jupyter-docker-compose
 Build the the image for the Jupyter Notebook server:
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 Start the Jupyter Notebook server:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 After running this command, the Jupyter Notebook server should be accessible at `http://localhost:8888`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,4 @@ services:
       - ./work:/home/jovyan/work
     ports:
       - 8888:8888
-    container_name: jupyter_notebook
     command: "start-notebook.sh --NotebookApp.token="


### PR DESCRIPTION
Minor fix in the readme to move to compose v2, the confguration should be still compatible with both: #4 

Also removes the container name prameter in order to be able to run multiple instances locally.