### PR TITLE
Switch to new source registry of jupyter docker images

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook
+FROM quay.io/jupyter/minimal-notebook:latest
 
 COPY ./requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
Resolves #6 by switching to the new contianer registry where images are hosted.

More details can be found in the [docker-stacks workflow](https://github.com/jupyter/docker-stacks/blob/main/.github/workflows/docker-tag-push.yml)